### PR TITLE
Drop SJCL in favor of Web Crypto API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@livechat/accounts-sdk",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/helpers/digest.js
+++ b/src/helpers/digest.js
@@ -1,0 +1,20 @@
+/* eslint-disable require-jsdoc */
+
+function digestMessage(message, algo = 'SHA-256') {
+  return new Promise((resolve, reject) => {
+    const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
+    // hash the message
+    window.crypto.subtle
+      .digest(algo, msgUint8)
+      .then((hashBuffer) => {
+        const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+        const hashHex = hashArray
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(''); // convert bytes to hex string
+        resolve(hashHex);
+      })
+      .catch((err) => reject(err));
+  });
+}
+
+export default digestMessage;


### PR DESCRIPTION
This is an attempt of switching to Web Crypto API for sha256 hashing. This will allow to drop sjcl dependency (which is great, but created before native APIs were available).

The only problem for now is that Web Crypto API is asynchronous (while sjcl is sync), so this will probably reflect higher up in all functions.

Todo:

- [x] Add function for hashing text based on Web Crypto API
- [ ] Covert sjcl usage to `digestMessage`
- [ ] Solve all the async vs sync problems
- [ ] Figure out how to write automated tests in Node