### PR TITLE
Fix return type comments

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -78,7 +78,7 @@ export default class AccountsSDK {
   /**
    * use iframe for authorization
    * @param {Object} options for overriding defaults
-   * @return {Object} instance of an iframe flow
+   * @return {Iframe} instance of an iframe flow
    */
   iframe(options = {}) {
     const localOptions = Object.assign({}, this.options, options);
@@ -88,7 +88,7 @@ export default class AccountsSDK {
   /**
    * use popup for authorization
    * @param {Object} options for overriding defaults
-   * @return {Object} instance of a popup flow
+   * @return {Popup} instance of a popup flow
    */
   popup(options = {}) {
     const localOptions = Object.assign({}, this.options, options);
@@ -98,7 +98,7 @@ export default class AccountsSDK {
   /**
    * use redirect for authorization
    * @param {Object} options for overriding defaults
-   * @return {Object} instance of a redirect flow
+   * @return {Redirect} instance of a redirect flow
    */
   redirect(options = {}) {
     const localOptions = Object.assign({}, this.options, options);


### PR DESCRIPTION
`@return {Object}` is too generic and confuses TypeScript when chaining objects like so:

<img width="213" alt="Screenshot 2023-01-18 at 12 10 34" src="https://user-images.githubusercontent.com/420812/213156712-19f58276-2af4-416c-a96d-d30aef29226f.png">
