### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/livechat/accounts-sdk/security/code-scanning/2](https://github.com/livechat/accounts-sdk/security/code-scanning/2)

In general, the problem is fixed by explicitly declaring a `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a CI workflow that only checks out code and runs local commands (lint, tests, build) without writing to the repo or GitHub resources, `contents: read` is sufficient and recommended.

The best fix here is to add a `permissions` block under the `lint-and-build` job (or at the workflow root). Since CodeQL flagged the job at line 12, we will add job-level permissions directly under `runs-on: ubuntu-latest`. Specifically, in `.github/workflows/ci.yml`, between line 12 (`runs-on: ubuntu-latest`) and line 14 (`steps:`), insert:

```yml
    permissions:
      contents: read
```

No additional imports or definitions are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
