### PR TITLE
chore: AS-1076 - migrate GitHub Actions workflows to ARC runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-and-build:
-    runs-on: ubuntu-latest
+    runs-on: default
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary
- Replaces `ubuntu-latest` → `runs-on: default` in `ci.yml`

Part of the ARC (Actions Runner Controller) rollout by the infra team. See [Slack thread](https://text.slack.com/archives/C08F0PTAHGC/p1773318241350099) for context.

Jira: [AS-1076](https://livechatinc.atlassian.net/browse/AS-1076)

## Test plan
- [ ] Verify CI workflow triggers and picks up jobs on the new runner after merge
- [ ] Monitor for any flaky runs and report back to infra team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AS-1076]: https://livechatinc.atlassian.net/browse/AS-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ