### PR TITLE
Bump version to 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3] - 2026-03-23
+
+### Security
+- Security patch
+
 ## [2.2.2] - 2026-03-11
 
 ### Changed
@@ -130,7 +135,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Updated readme with new features and usage
 
-[Unreleased]: https://github.com/livechat/accounts-sdk/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/livechat/accounts-sdk/compare/v2.2.3...HEAD
+[2.2.3]: https://github.com/livechat/accounts-sdk/compare/v2.2.2...v2.2.3
+[2.2.2]: https://github.com/livechat/accounts-sdk/compare/v2.2.1...v2.2.2
+[2.2.1]: https://github.com/livechat/accounts-sdk/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/livechat/accounts-sdk/compare/v2.1.3...v2.2.0
 [2.1.3]: https://github.com/livechat/accounts-sdk/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/livechat/accounts-sdk/compare/v2.1.1...v2.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@livechat/accounts-sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@livechat/accounts-sdk",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "js-cookie": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/accounts-sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "SDK for 'Sign in with LiveChat'.",
   "author": "LiveChat",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Security patch release (2.2.2 → 2.2.3)
- Updated CHANGELOG.md with new version entry

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 65 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)