### PR TITLE
AS-1114: add code_challenge_method and deprecate code_challange_method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Development Setup
+
+```bash
+npm install
+npm run build   # build dist files
+npm test        # run tests
+npm run lint    # lint source
+```
+
+For active development with file watching:
+
+```bash
+npm start
+```
+
+## Docs
+
+- [Release process & beta releases](docs/releasing.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,4 @@ npm test        # run tests
 npm run lint    # lint source
 ```
 
-For active development with file watching:
-
-```bash
-npm start
-```
-
-## Docs
-
-- [Release process & beta releases](docs/releasing.md)
+To test changes in your application, publish a beta release and install it. See [Release process & beta releases](docs/releasing.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,9 +4041,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5155,9 +5155,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7679,9 +7679,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -107,4 +107,4 @@ See [CHANGELOG.md](https://github.com/livechat/accounts-sdk/blob/master/CHANGELO
 
 ## Contributing
 
-For internal development notes (SJCL vendor build, release process, beta releases), see the [docs/](docs/) directory.
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,8 @@ sdk.redirect().authorizeData().then((authorizeData)=>{
 - `pkce.enabled=true` **bool** Oauth 2.1 PKCE extension enabled for `code` grant
 - `pkce.code_verifier` **string** override auto generated code verifier
 - `pkce.code_verifier_length=128` **number** code verifier length, between 43 and 128 characters https://tools.ietf.org/html/rfc7636#section-4.1
-- `pkce.code_challange_method='S256'` **string** code challange method, use `S256` or `plain`
+- `pkce.code_challenge_method='S256'` **string** code challenge method, use `S256` or `plain`
+- `pkce.code_challange_method` **string** **Deprecated.** Use `code_challenge_method` instead. Will be removed in v3.0.0.
 
 ## Changelog
 

--- a/src/sdk.authorization-url.test.js
+++ b/src/sdk.authorization-url.test.js
@@ -133,7 +133,7 @@ describe('sdk.authorizeURL()', function () {
         pkce: {
           enabled: true,
           code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-1234567890',
-          code_challange_method: 'plain',
+          code_challenge_method: 'plain',
         },
       });
       const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
@@ -150,7 +150,7 @@ describe('sdk.authorizeURL()', function () {
           pkce: {
             enabled: true,
             code_verifier: 'override-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-1234567890',
-            code_challange_method: 'plain',
+            code_challenge_method: 'plain',
           },
         })
       );
@@ -167,7 +167,7 @@ describe('sdk.authorizeURL()', function () {
         pkce: {
           enabled: true,
           code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
-          code_challange_method: 'plain',
+          code_challenge_method: 'plain',
         },
       });
       const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
@@ -192,7 +192,7 @@ describe('sdk.authorizeURL()', function () {
         pkce: {
           enabled: true,
           code_verifier: 'test-plain-verifier-1234567890-abcdefghijklmnopqrstuvwxyz',
-          code_challange_method: 'plain',
+          code_challenge_method: 'plain',
         },
       });
       const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
@@ -208,7 +208,7 @@ describe('sdk.authorizeURL()', function () {
       sdk = new SDK({
         client_id: 'test-client-id',
         response_type: 'code',
-        pkce: { enabled: true, code_verifier: customVerifier, code_challange_method: 'plain' },
+        pkce: { enabled: true, code_verifier: customVerifier, code_challenge_method: 'plain' },
       });
       const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
       expect(query.code_challenge).toBe(customVerifier);
@@ -223,7 +223,7 @@ describe('sdk.authorizeURL()', function () {
         pkce: {
           enabled: true,
           code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
-          code_challange_method: 'S256',
+          code_challenge_method: 'S256',
         },
       });
       const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
@@ -236,6 +236,45 @@ describe('sdk.authorizeURL()', function () {
       const query = parseQuery(sdk.authorizeURL());
       expect(query.code_challenge).toBeUndefined();
       expect(query.code_challenge_method).toBeUndefined();
+    });
+
+    describe('code_challenge_method option', function () {
+      it('uses code_challenge_method when provided', function () {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        sdk = new SDK({
+          client_id: 'test-client-id',
+          response_type: 'code',
+          pkce: {
+            enabled: true,
+            code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
+            code_challenge_method: 'plain',
+          },
+        });
+        const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
+        expect(query.code_challenge_method).toBe('plain');
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+      });
+
+      it('accepts code_challange_method, emits a deprecation warning, and normalises it', function () {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        sdk = new SDK({
+          client_id: 'test-client-id',
+          response_type: 'code',
+          pkce: {
+            enabled: true,
+            code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
+            code_challange_method: 'plain',
+          },
+        });
+        const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
+        expect(query.code_challenge_method).toBe('plain');
+        expect(warnSpy).toHaveBeenCalledWith(
+          // eslint-disable-next-line max-len
+          '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
+        );
+        warnSpy.mockRestore();
+      });
     });
   });
 

--- a/src/sdk.authorization-url.test.js
+++ b/src/sdk.authorization-url.test.js
@@ -275,6 +275,27 @@ describe('sdk.authorizeURL()', function () {
         );
         warnSpy.mockRestore();
       });
+
+      it('accepts code_challange_method as a per-call override to authorizeURL', function () {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        sdk = new SDK({ client_id: 'test-client-id', response_type: 'code' });
+        const query = parseQuery(
+          sdk.authorizeURL({
+            state: 'test-state',
+            pkce: {
+              enabled: true,
+              code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
+              code_challange_method: 'plain',
+            },
+          })
+        );
+        expect(query.code_challenge_method).toBe('plain');
+        expect(warnSpy).toHaveBeenCalledWith(
+          // eslint-disable-next-line max-len
+          '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
+        );
+        warnSpy.mockRestore();
+      });
     });
   });
 

--- a/src/sdk.authorization-url.test.js
+++ b/src/sdk.authorization-url.test.js
@@ -239,8 +239,12 @@ describe('sdk.authorizeURL()', function () {
     });
 
     describe('code_challenge_method option', function () {
+      afterEach(function () {
+        jest.restoreAllMocks();
+      });
+
       it('uses code_challenge_method when provided', function () {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
         sdk = new SDK({
           client_id: 'test-client-id',
           response_type: 'code',
@@ -252,12 +256,11 @@ describe('sdk.authorizeURL()', function () {
         });
         const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
         expect(query.code_challenge_method).toBe('plain');
-        expect(warnSpy).not.toHaveBeenCalled();
-        warnSpy.mockRestore();
+        expect(console.warn).not.toHaveBeenCalled();
       });
 
       it('accepts code_challange_method, emits a deprecation warning, and normalises it', function () {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
         sdk = new SDK({
           client_id: 'test-client-id',
           response_type: 'code',
@@ -269,15 +272,31 @@ describe('sdk.authorizeURL()', function () {
         });
         const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
         expect(query.code_challenge_method).toBe('plain');
-        expect(warnSpy).toHaveBeenCalledWith(
+        expect(console.warn).toHaveBeenCalledWith(
           // eslint-disable-next-line max-len
           '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
         );
-        warnSpy.mockRestore();
+      });
+
+      it('code_challenge_method takes precedence over code_challange_method when both are supplied', function () {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        sdk = new SDK({
+          client_id: 'test-client-id',
+          response_type: 'code',
+          pkce: {
+            enabled: true,
+            code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
+            code_challenge_method: 'plain',
+            code_challange_method: 'S256',
+          },
+        });
+        const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
+        expect(query.code_challenge_method).toBe('plain');
+        expect(console.warn).toHaveBeenCalled();
       });
 
       it('accepts code_challange_method as a per-call override to authorizeURL', function () {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
         sdk = new SDK({ client_id: 'test-client-id', response_type: 'code' });
         const query = parseQuery(
           sdk.authorizeURL({
@@ -290,11 +309,10 @@ describe('sdk.authorizeURL()', function () {
           })
         );
         expect(query.code_challenge_method).toBe('plain');
-        expect(warnSpy).toHaveBeenCalledWith(
+        expect(console.warn).toHaveBeenCalledWith(
           // eslint-disable-next-line max-len
           '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
         );
-        warnSpy.mockRestore();
       });
     });
   });

--- a/src/sdk.initialization.test.js
+++ b/src/sdk.initialization.test.js
@@ -50,10 +50,11 @@ describe('SDK Initialization', function () {
 
     expect(sdk.options.pkce.enabled).toBe(true);
     expect(sdk.options.pkce.code_verifier_length).toBe(128);
-    expect(sdk.options.pkce.code_challange_method).toBe('S256');
+    expect(sdk.options.pkce.code_challenge_method).toBe('S256');
   });
 
   it('should allow custom PKCE configuration', function () {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const sdk = new SDK({
       client_id: 'test-client-id',
       pkce: {
@@ -65,7 +66,8 @@ describe('SDK Initialization', function () {
 
     expect(sdk.options.pkce.enabled).toBe(false);
     expect(sdk.options.pkce.code_verifier_length).toBe(64);
-    expect(sdk.options.pkce.code_challange_method).toBe('plain');
+    expect(sdk.options.pkce.code_challenge_method).toBe('plain');
+    warnSpy.mockRestore();
   });
 
   it('should initialize transaction manager', function () {

--- a/src/sdk.initialization.test.js
+++ b/src/sdk.initialization.test.js
@@ -1,6 +1,10 @@
 import SDK from './sdk';
 
 describe('SDK Initialization', function () {
+  afterEach(function () {
+    jest.restoreAllMocks();
+  });
+
   it('should throw error when client_id is missing', function () {
     expect(() => new SDK()).toThrow(/client id not provided/);
     expect(() => new SDK({})).toThrow(/client id not provided/);
@@ -54,7 +58,7 @@ describe('SDK Initialization', function () {
   });
 
   it('should allow custom PKCE configuration', function () {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     const sdk = new SDK({
       client_id: 'test-client-id',
       pkce: {
@@ -67,7 +71,6 @@ describe('SDK Initialization', function () {
     expect(sdk.options.pkce.enabled).toBe(false);
     expect(sdk.options.pkce.code_verifier_length).toBe(64);
     expect(sdk.options.pkce.code_challenge_method).toBe('plain');
-    warnSpy.mockRestore();
   });
 
   it('should initialize transaction manager', function () {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -7,8 +7,8 @@ import sjcl from './vendor/sjcl';
 import {pick} from './helpers/object';
 import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
-
 import random from './helpers/random';
+
 /**
  * Accounts SDK main class
  */
@@ -39,7 +39,8 @@ export default class AccountsSDK {
    * @param {string} [options.pkce.code_verifier] override auto generated code verifier
    * @param {number} [options.pkce.code_verifier_length] code verifier length, between 43 and 128 characters
    *   https://tools.ietf.org/html/rfc7636#section-4.1 (default: `128`)
-   * @param {string} [options.pkce.code_challange_method] code challange method, use `S256` or `plain` (default: `S256`)
+   * @param {string} [options.pkce.code_challenge_method] code challenge method, use `S256` or `plain` (default: `S256`)
+   * @param {string} [options.pkce.code_challange_method] **Deprecated.** Use `code_challenge_method` instead.
    */
   constructor(options = {}) {
     if (options.client_id == null) {
@@ -70,11 +71,23 @@ export default class AccountsSDK {
       pkce: {
         enabled: true,
         code_verifier_length: 128,
-        code_challange_method: 'S256',
+        code_challenge_method: 'S256',
       },
     };
 
     this.options = Object.assign({}, defaultOptions, options);
+
+    if (this.options.pkce && this.options.pkce.code_challange_method !== undefined) {
+      console.warn(
+        // eslint-disable-next-line max-len
+        '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
+      );
+      if (this.options.pkce.code_challenge_method === undefined) {
+        this.options.pkce.code_challenge_method = this.options.pkce.code_challange_method;
+      }
+      delete this.options.pkce.code_challange_method;
+    }
+
     this.transaction = new Transaction(this.options);
     this.redirectUriParamsPersister = new RedirectUriParamsPersister(
       this.options
@@ -166,7 +179,7 @@ export default class AccountsSDK {
         localOptions.pkce.code_verifier ||
         random.string(localOptions.pkce.code_verifier_length);
 
-      switch (localOptions.pkce.code_challange_method) {
+      switch (localOptions.pkce.code_challenge_method) {
         case 'S256': {
           const hashBits = sjcl.hash.sha256.hash(codeVerifier);
           const hashBytes = hashBits.reduce((s, w) =>
@@ -174,7 +187,7 @@ export default class AccountsSDK {
           Object.assign(params, {
             code_verifier: codeVerifier,
             code_challenge: encoding.base64URLEncode(hashBytes),
-            code_challenge_method: localOptions.pkce.code_challange_method,
+            code_challenge_method: localOptions.pkce.code_challenge_method,
           });
           break;
         }
@@ -183,7 +196,7 @@ export default class AccountsSDK {
           Object.assign(params, {
             code_verifier: codeVerifier,
             code_challenge: codeVerifier,
-            code_challenge_method: localOptions.pkce.code_challange_method,
+            code_challenge_method: localOptions.pkce.code_challenge_method,
           });
       }
     }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -9,6 +9,20 @@ import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
 
+function normalizePkce(pkce) {
+  if (!pkce || pkce.code_challange_method === undefined) {
+    return pkce;
+  }
+  const normalized = Object.assign({}, pkce);
+  // eslint-disable-next-line max-len
+  console.warn('[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.');
+  if (normalized.code_challenge_method === undefined) {
+    normalized.code_challenge_method = normalized.code_challange_method;
+  }
+  delete normalized.code_challange_method;
+  return normalized;
+}
+
 /**
  * Accounts SDK main class
  */
@@ -76,18 +90,7 @@ export default class AccountsSDK {
     };
 
     this.options = Object.assign({}, defaultOptions, options);
-
-    if (this.options.pkce && this.options.pkce.code_challange_method !== undefined) {
-      console.warn(
-        // eslint-disable-next-line max-len
-        '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
-      );
-      if (this.options.pkce.code_challenge_method === undefined) {
-        this.options.pkce.code_challenge_method = this.options.pkce.code_challange_method;
-      }
-      delete this.options.pkce.code_challange_method;
-    }
-
+    this.options.pkce = normalizePkce(this.options.pkce);
     this.transaction = new Transaction(this.options);
     this.redirectUriParamsPersister = new RedirectUriParamsPersister(
       this.options
@@ -132,6 +135,7 @@ export default class AccountsSDK {
    */
   authorizeURL(options = {}, flow = '') {
     const localOptions = Object.assign({}, this.options, options);
+    localOptions.pkce = normalizePkce(localOptions.pkce);
 
     if (!localOptions.state) {
       localOptions.state = random.string(localOptions.key_length);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -11,8 +11,8 @@ import random from './helpers/random';
 
 /**
  * Normalize PKCE options, support deprecated code_challange_method option
- * @param {object} pkce PKCE options
- * @returns {object} normalized PKCE options
+ * @param {object|undefined} pkce PKCE options
+ * @returns {object|undefined} normalized PKCE options
  */
 function normalizePkce(pkce) {
   if (!pkce || pkce.code_challange_method === undefined) {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -9,6 +9,11 @@ import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
 
+/**
+ * Normalize PKCE options, support deprecated code_challange_method option
+ * @param {object} pkce PKCE options
+ * @returns {object} normalized PKCE options
+ */
 function normalizePkce(pkce) {
   if (!pkce || pkce.code_challange_method === undefined) {
     return pkce;


### PR DESCRIPTION
## Summary

- Introduces the correctly-spelled `pkce.code_challenge_method` option as the canonical API
- Keeps `pkce.code_challange_method` working but emits a `console.warn` deprecation notice
- Normalises the old spelling to the new key internally; `code_challenge_method` takes precedence when both are supplied
- Updates README to document the canonical option and mark the old one as deprecated

Jira: https://livechatinc.atlassian.net/browse/AS-1114

## Test plan

- [ ] Existing PKCE tests updated to use `code_challenge_method`
- [ ] New `describe('code_challenge_method option')` block with two tests: one for each spelling in isolation
- [ ] `sdk.initialization.test.js` updated to assert on `code_challenge_method` and silence the expected warning for the deprecated-spelling test
- [ ] All 139 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)