### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
## SHA Pinning — automated PR

This PR pins all GitHub Actions workflow steps to immutable commit SHAs.

### What changed

All mutable GitHub Actions tag references (e.g. `@v3`) have been replaced with immutable commit SHA pins plus a version comment, for example:

```yaml
# before
- uses: actions/checkout@v4
# after
- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Dependabot will keep the SHA pins up-to-date – it's natively [supported by GitHub](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/).

### Why

A mutable tag can be silently re-pointed to a malicious commit. SHA pins guarantee exactly which code runs in CI.  
See: [tj-actions/changed-files incident (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)

### Review checklist

- [ ] Spot-check a few SHA pins against the upstream action repo
- [ ] Verify CI still passes after merge
- [ ] **Merge into `master`**
