### PR TITLE
chore: update team slug references in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @livechat/admin-subscription-experience
+* @livechat/accounts-subscription-frontend


### PR DESCRIPTION
## GitHub Teams cleanup – automated PR

This PR was opened automatically as part of [ENG-122](https://livechatinc.atlassian.net/browse/ENG-122) (GitHub Teams cleanup).

> [!IMPORTANT]
> **Please merge this PR yourselves.** This is an org-wide initiative across multiple repos. @bolchowka opened it automatically but **will not** merge PRs himself. Once you've reviewed and CI is green, the team responsible for this repo should merge it. Thank you! 🙏

## What changed

Updates team slugs in CODEOWNERS as part of the GitHub teams migration.

**Teams referenced after migration:**
- `@livechat/accounts-subscription-frontend`

## Why

To clean up redundant/legacy GitHub Teams.

## How to test

N/A

## AI assistance

- [ ] No AI tools were used to author this PR
- [x] AI tools were used, and I have fully reviewed and verified every line of the output

## Jira

https://livechatinc.atlassian.net/browse/ENG-122

[ENG-122]: https://livechatinc.atlassian.net/browse/ENG-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ