### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint-and-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions: read-all
+
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Workflow Permissions — automated PR

This PR adds explicit `permissions: read-all` to all workflow files that previously lacked a top-level permissions declaration.

> [!WARNING]
> **Some CI jobs may fail after merge** if they rely on write access that is now restricted by `permissions: read-all`. See the checklist below for how to identify and fix this before merging.

### What changed

Every workflow file that previously lacked a top-level `permissions:` declaration now has:

```yaml
permissions: read-all
```

added just before the `jobs:` block.

### Why

Without explicit permissions, workflow jobs inherit the repository or organisation default for GITHUB_TOKEN, which may be full write access. `permissions: read-all` makes all scopes explicitly read-only and eliminates reliance on that default.

### What to check before merging

Scan each workflow job for operations that need write access and add the corresponding permission at job level if missing:

| Operation | Permission needed |
|-----------|-------------------|
| Push commits / create tags | `contents: write` |
| Create / update releases | `contents: write` |
| Create or comment on PRs | `pull-requests: write` |
| Publish packages to GitHub Packages | `packages: write` |
| Write issues or comments | `issues: write` |
| Deploy to GitHub Pages | `pages: write` |
| Request OIDC token (cloud auth) | `id-token: write` |
| Upload to security dashboard | `security-events: write` |

Example — job that needs to push commits and open a PR:

```yaml
jobs:
  release:
    permissions:
      contents: write
      pull-requests: write
    steps:
      - ...
```

Full reference: [GitHub Actions permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

### Review checklist

- [ ] Scan each workflow job for write operations (see table above)
- [ ] Add job-level `permissions:` for any job needing write access
- [ ] Confirm CI is green after merge
- [ ] **Merge into `master`**
