### PR TITLE
feat: remove deprecated code_challange_method option (AS-1115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Remove deprecated `pkce.code_challange_method` option — use `pkce.code_challenge_method` instead
+
 ## [2.3.0] - 2026-03-30
 
 ### Added

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,6 @@ sdk.redirect().authorizeData().then((authorizeData)=>{
 - `pkce.code_verifier` **string** override auto generated code verifier
 - `pkce.code_verifier_length=128` **number** code verifier length, between 43 and 128 characters https://tools.ietf.org/html/rfc7636#section-4.1
 - `pkce.code_challenge_method='S256'` **string** code challenge method, use `S256` or `plain`
-- `pkce.code_challange_method` **string** **Deprecated.** Use `code_challenge_method` instead. Will be removed in v3.0.0.
 
 ## Changelog
 

--- a/src/sdk.authorization-url.test.ts
+++ b/src/sdk.authorization-url.test.ts
@@ -239,12 +239,7 @@ describe('sdk.authorizeURL()', function () {
     });
 
     describe('code_challenge_method option', function () {
-      afterEach(function () {
-        jest.restoreAllMocks();
-      });
-
       it('uses code_challenge_method when provided', function () {
-        jest.spyOn(console, 'warn').mockImplementation(() => {});
         sdk = new SDK({
           client_id: 'test-client-id',
           response_type: 'code',
@@ -256,63 +251,6 @@ describe('sdk.authorizeURL()', function () {
         });
         const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
         expect(query.code_challenge_method).toBe('plain');
-        expect(console.warn).not.toHaveBeenCalled();
-      });
-
-      it('accepts code_challange_method, emits a deprecation warning, and normalises it', function () {
-        jest.spyOn(console, 'warn').mockImplementation(() => {});
-        sdk = new SDK({
-          client_id: 'test-client-id',
-          response_type: 'code',
-          pkce: {
-            enabled: true,
-            code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
-            code_challange_method: 'plain',
-          },
-        });
-        const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
-        expect(query.code_challenge_method).toBe('plain');
-        expect(console.warn).toHaveBeenCalledWith(
-          // eslint-disable-next-line max-len
-          '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
-        );
-      });
-
-      it('code_challenge_method takes precedence over code_challange_method when both are supplied', function () {
-        jest.spyOn(console, 'warn').mockImplementation(() => {});
-        sdk = new SDK({
-          client_id: 'test-client-id',
-          response_type: 'code',
-          pkce: {
-            enabled: true,
-            code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
-            code_challenge_method: 'plain',
-            code_challange_method: 'S256',
-          },
-        });
-        const query = parseQuery(sdk.authorizeURL({ state: 'test-state' }));
-        expect(query.code_challenge_method).toBe('plain');
-        expect(console.warn).toHaveBeenCalled();
-      });
-
-      it('accepts code_challange_method as a per-call override to authorizeURL', function () {
-        jest.spyOn(console, 'warn').mockImplementation(() => {});
-        sdk = new SDK({ client_id: 'test-client-id', response_type: 'code' });
-        const query = parseQuery(
-          sdk.authorizeURL({
-            state: 'test-state',
-            pkce: {
-              enabled: true,
-              code_verifier: 'test-verifier-1234567890-abcdefghijklmnopqrstuvwxyz-plain-method',
-              code_challange_method: 'plain',
-            },
-          })
-        );
-        expect(query.code_challenge_method).toBe('plain');
-        expect(console.warn).toHaveBeenCalledWith(
-          // eslint-disable-next-line max-len
-          '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.'
-        );
       });
     });
   });

--- a/src/sdk.initialization.test.ts
+++ b/src/sdk.initialization.test.ts
@@ -66,7 +66,7 @@ describe('SDK Initialization', function () {
       pkce: {
         enabled: false,
         code_verifier_length: 64,
-        code_challange_method: 'plain',
+        code_challenge_method: 'plain',
       },
     });
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -14,7 +14,6 @@ import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
 import {
-  type PKCEOptions,
   type SDKOptions,
   type ResolvedOptions,
 } from './types/sdk';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -26,24 +26,6 @@ import {
 } from './types/authentication';
 
 /**
- * Normalize PKCE options, support deprecated code_challange_method option.
- */
-function normalizePkce(pkce: PKCEOptions | undefined): PKCEOptions | undefined {
-  if (pkce?.code_challange_method === undefined) {
-    return pkce;
-  }
-  const normalized = Object.assign({}, pkce);
-
-  console.warn(
-    // eslint-disable-next-line max-len
-    '[accounts-sdk] pkce.code_challange_method is deprecated and will be removed in v3.0.0. Use code_challenge_method instead.',
-  );
-  normalized.code_challenge_method ??= normalized.code_challange_method;
-  delete normalized.code_challange_method;
-  return normalized;
-}
-
-/**
  * Accounts SDK main class for "Sign in with LiveChat".
  */
 export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
@@ -85,7 +67,6 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
     };
 
     this.options = Object.assign({}, defaultOptions, options);
-    this.options.pkce = normalizePkce(this.options.pkce) as PKCEOptions;
     this.transaction = new Transaction(this.options);
     this.redirectUriParamsPersister = new RedirectUriParamsPersister(
       this.options,
@@ -127,8 +108,6 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       this.options,
       options,
     );
-    localOptions.pkce = normalizePkce(localOptions.pkce) as PKCEOptions;
-
     if (!localOptions.state) {
       localOptions.state = random.string(localOptions.transaction.key_length);
     }

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -18,8 +18,6 @@ export type PKCEOptions = {
    * `'S256'` (SHA-256, recommended) or `'plain'`.
    */
   code_challenge_method?: string;
-  /** @deprecated Use `code_challenge_method` instead. */
-  code_challange_method?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Removes the deprecated `pkce.code_challange_method` option entirely — only `pkce.code_challenge_method` is accepted going forward
- Removes the compatibility shim, `console.warn` deprecation notice, and the `code_challange_method` type field
- Removes all tests covering the deprecated spelling and cleans up related README docs

## Jira
[AS-1115](https://livechatinc.atlassian.net/browse/AS-1115)

## Test plan
- [x] All existing tests pass (`npm test`)
- [x] No references to `code_challange_method` remain in source, types, tests, or docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AS-1115]: https://livechatinc.atlassian.net/browse/AS-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ