### PR TITLE
chore: add Aikido Safe Chain to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Set up Aikido Safe Chain
+        uses: livechat/github-actions-global/.github/actions/safe-chain-install@master
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Aikido Safe Chain — automated PR

This PR injects a Safe Chain setup step into CI workflows before package-manager install steps.

### What changed

A `Set up Aikido Safe Chain` step was injected before the first package-manager install step in every job that installs npm, pip, or yarn packages.

### Why

Safe Chain intercepts all package downloads via a local proxy that blocks known malware and enforces a 48-hour minimum package age, preventing day-zero supply chain attacks.

See: [AikidoSec/safe-chain](https://github.com/AikidoSec/safe-chain)

### Review checklist

- [ ] Confirm the new step appears before the install step(s) in each affected job
- [ ] Verify CI is still green after merge
- [ ] **Merge into `master`**