### PR TITLE
fix: AS-928 transaction.generate undefined state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `object.mergeDeep()` utility for recursive object merging
+- Add `object.omitBy()` utility for filtering object properties by predicate
+
+### Changed
+- `pick()` now preserves falsy values (`0`, `false`, `""`, `null`) — only `undefined` properties are dropped
+
+### Fixed
+- Fix default options with nested properties being overwritten when merging
+- Fix `transaction.generate` passing `undefined` state
+- Omit empty string and `null` values from `authorizeURL` query parameters
+
 ### Removed
 - Remove deprecated `pkce.code_challange_method` option — use `pkce.code_challenge_method` instead
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add `object.mergeDeep()` utility for recursive object merging
+- Add `object.deepMerge()` utility for recursive object merging
 - Add `object.omitBy()` utility for filtering object properties by predicate
 
 ### Changed

--- a/src/helpers/object.test.ts
+++ b/src/helpers/object.test.ts
@@ -1,4 +1,122 @@
-import {pick} from './object';
+import {deepMerge, pick} from './object';
+import {type SDKOptions} from '../types/sdk';
+
+describe('helpers/deepMerge', function () {
+  describe('shallow fields', function () {
+    it('merges top-level primitive fields', function () {
+      const target: SDKOptions = {client_id: 'aaa', response_type: 'token'};
+      const result = deepMerge(target, {response_type: 'code'});
+      expect(result).toEqual({client_id: 'aaa', response_type: 'code'});
+    });
+
+    it('adds new fields from source', function () {
+      const target: SDKOptions = {client_id: 'aaa'};
+      const result = deepMerge(target, {prompt: 'consent'});
+      expect(result).toEqual({client_id: 'aaa', prompt: 'consent'});
+    });
+
+    it('does not overwrite target value when source value is undefined', function () {
+      const target: SDKOptions = {client_id: 'aaa', prompt: 'consent'};
+      const result = deepMerge(target, {prompt: undefined});
+      expect(result.prompt).toBe('consent');
+    });
+
+    it('preserves falsy source values (null, empty string, false, 0)', function () {
+      const target: SDKOptions = {
+        client_id: 'aaa',
+        scope: 'agents--all:rw',
+        email_hint: 'user@example.com',
+        verify_state: true,
+      };
+      const result = deepMerge(target, {
+        scope: null,
+        email_hint: '',
+        verify_state: false,
+      });
+      expect(result.scope).toBeNull();
+      expect(result.email_hint).toBe('');
+      expect(result.verify_state).toBe(false);
+    });
+  });
+
+  describe('nested plain objects', function () {
+    it('deep merges tracking options', function () {
+      const target: SDKOptions = {
+        client_id: 'aaa',
+        tracking: {utm_source: 'app', utm_medium: 'web'},
+      };
+      const result = deepMerge(target, {tracking: {utm_campaign: 'launch'}});
+      expect(result.tracking).toEqual({
+        utm_source: 'app',
+        utm_medium: 'web',
+        utm_campaign: 'launch',
+      });
+    });
+
+    it('deep merges transaction options', function () {
+      const target: SDKOptions = {
+        client_id: 'aaa',
+        transaction: {namespace: 'com.livechat', key_length: 32},
+      };
+      const result = deepMerge(target, {
+        transaction: {force_local_storage: true},
+      });
+      expect(result.transaction).toEqual({
+        namespace: 'com.livechat',
+        key_length: 32,
+        force_local_storage: true,
+      });
+    });
+
+    it('deep merges pkce options', function () {
+      const target: SDKOptions = {
+        client_id: 'aaa',
+        pkce: {enabled: true, code_verifier_length: 128},
+      };
+      const result = deepMerge(target, {
+        pkce: {code_challenge_method: 'S256'},
+      });
+      expect(result.pkce).toEqual({
+        enabled: true,
+        code_verifier_length: 128,
+        code_challenge_method: 'S256',
+      });
+    });
+  });
+
+  describe('multiple sources', function () {
+    it('applies sources left-to-right', function () {
+      const target: SDKOptions = {client_id: 'aaa'};
+      const result = deepMerge(
+        target,
+        {response_type: 'token'},
+        {response_type: 'code'},
+      );
+      expect(result.response_type).toBe('code');
+    });
+
+    it('deep merges nested objects across multiple sources', function () {
+      const target: SDKOptions = {client_id: 'aaa'};
+      const result = deepMerge(
+        target,
+        {tracking: {utm_source: 'app'}},
+        {tracking: {utm_medium: 'web'}},
+      );
+      expect(result.tracking).toEqual({utm_source: 'app', utm_medium: 'web'});
+    });
+  });
+
+  describe('immutability', function () {
+    it('does not mutate the target', function () {
+      const target: SDKOptions = {
+        client_id: 'aaa',
+        tracking: {utm_source: 'app'},
+      };
+      deepMerge(target, {tracking: {utm_medium: 'web'}});
+      expect(target.tracking).toEqual({utm_source: 'app'});
+    });
+  });
+});
 
 describe('helpers/pick', function () {
   it('returns only the requested keys', function () {

--- a/src/helpers/object.test.ts
+++ b/src/helpers/object.test.ts
@@ -1,4 +1,4 @@
-import {deepMerge, pick} from './object';
+import {deepMerge, omitBy, pick} from './object';
 import {type SDKOptions} from '../types/sdk';
 
 describe('helpers/deepMerge', function () {
@@ -115,6 +115,32 @@ describe('helpers/deepMerge', function () {
       deepMerge(target, {tracking: {utm_medium: 'web'}});
       expect(target.tracking).toEqual({utm_source: 'app'});
     });
+  });
+});
+
+describe('helpers/omitBy', function () {
+  it('omits properties where predicate returns true', function () {
+    expect(omitBy({a: '', b: 'hello', c: ''}, (v) => v === '')).toEqual({
+      b: 'hello',
+    });
+  });
+
+  it('keeps all properties when predicate always returns false', function () {
+    expect(omitBy({a: 1, b: 2}, () => false)).toEqual({a: 1, b: 2});
+  });
+
+  it('returns an empty object when predicate always returns true', function () {
+    expect(omitBy({a: 1, b: 2}, () => true)).toEqual({});
+  });
+
+  it('does not mutate the source object', function () {
+    const src = {a: '', b: 'hello'};
+    omitBy(src, (v) => v === '');
+    expect(src).toEqual({a: '', b: 'hello'});
+  });
+
+  it('returns an empty object for an empty input', function () {
+    expect(omitBy({}, () => true)).toEqual({});
   });
 });
 

--- a/src/helpers/object.test.ts
+++ b/src/helpers/object.test.ts
@@ -6,16 +6,28 @@ describe('helpers/pick', function () {
   });
 
   it('ignores keys not present in the source object', function () {
+    // @ts-expect-error Testing behavior with non-existent keys
     expect(pick({a: 1}, ['a', 'missing'])).toEqual({a: 1});
   });
 
   it('returns an empty object when no keys match', function () {
+    // @ts-expect-error Testing behavior with non-existent keys
     expect(pick({a: 1}, ['x', 'y'])).toEqual({});
   });
 
-  it('silently drops falsy values (0, false, empty string, null)', function () {
-    // pick uses a truthy check — this is intentional Auth0 behaviour
+  it('keeps falsy values (0, false, empty string, null)', function () {
     const src = {zero: 0, flag: false, empty: '', nothing: null, ok: 'yes'};
-    expect(pick(src, ['zero', 'flag', 'empty', 'nothing', 'ok'])).toEqual({ok: 'yes'});
+    expect(pick(src, ['zero', 'flag', 'empty', 'nothing', 'ok'])).toEqual({
+      zero: 0,
+      flag: false,
+      empty: '',
+      nothing: null,
+      ok: 'yes',
+    });
+  });
+
+  it('drops keys with undefined values', function () {
+    const src = {defined: 'value', missing: undefined};
+    expect(pick(src, ['defined', 'missing'])).toEqual({defined: 'value'});
   });
 });

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -1,16 +1,32 @@
 /**
- * @author Auth0 https://github.com/auth0/auth0.js
- * @license MIT
+ * Creates a new object composed of the picked object properties.
+ *
+ * This function takes an object and an array of keys, and returns a new object that
+ * includes only the properties corresponding to the specified keys.
+ * @template T - The type of object.
+ * @template K - The type of keys in object.
+ * @param {T} obj - The object to pick keys from.
+ * @param {K[]} keys - An array of keys to be picked from the object.
+ * @returns {Pick<T, K>} A new object with the specified keys picked.
+ * @example
+ * const obj = { a: 1, b: 2, c: 3 };
+ * const result = pick(obj, ['a', 'c']);
+ * // result will be { a: 1, c: 3 }
+ * @see [es-toolkit/pick](https://github.com/toss/es-toolkit/blob/970ae85401f7e43c938bb83535d9145297bdf6cc/src/object/pick.ts)
  */
-export function pick<T extends object, K extends PropertyKey>(
-  object: T,
-  keys: K[],
-): Partial<Pick<T, Extract<K, keyof T>>> {
-  return keys.reduce<Partial<T>>((prev, key) => {
-    const val = (object as Record<PropertyKey, unknown>)[key];
-    if (val) {
-      (prev as Record<PropertyKey, unknown>)[key] = val;
+export function pick<T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  keys: readonly K[],
+): Pick<T, K> {
+  const result = {} as Pick<T, K>;
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
     }
-    return prev;
-  }, {}) as Partial<Pick<T, Extract<K, keyof T>>>;
+  }
+
+  return result;
 }

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -12,13 +12,12 @@
  * const obj = { a: 1, b: 2, c: 3 };
  * const result = pick(obj, ['a', 'c']);
  * // result will be { a: 1, c: 3 }
- * @see [es-toolkit/pick](https://github.com/toss/es-toolkit/blob/970ae85401f7e43c938bb83535d9145297bdf6cc/src/object/pick.ts)
  */
 export function pick<T extends Record<string, unknown>, K extends keyof T>(
   obj: T,
   keys: readonly K[],
 ): Pick<T, K> {
-  const result = {} as Pick<T, K>;
+  const result = Object.create(null) as Pick<T, K>;
 
   for (const key of keys) {
     if (obj[key] !== undefined) {
@@ -36,7 +35,7 @@ type DeepPartial<T> = {
 };
 
 /**
- * Recursively merges own enumerable properties of source objects into the target object.
+ * Recursively merges properties of source objects into the target object.
  * Plain object values are merged recursively; all other values (arrays, primitives, class instances)
  * are replaced by the source value. Source `undefined` values do not overwrite target values.
  */
@@ -75,7 +74,7 @@ export function omitBy<T extends Record<string, unknown>>(
   obj: T,
   predicate: (value: T[keyof T], key: keyof T) => boolean,
 ): Partial<T> {
-  const result: Partial<T> = {};
+  const result: Partial<T> = Object.create(null);
 
   for (const key in obj) {
     if (

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -30,3 +30,43 @@ export function pick<T extends Record<string, unknown>, K extends keyof T>(
 
   return result;
 }
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : T[K];
+};
+
+/**
+ * Recursively merges own enumerable properties of source objects into the target object.
+ * Plain object values are merged recursively; all other values (arrays, primitives, class instances)
+ * are replaced by the source value. Source `undefined` values do not overwrite target values.
+ */
+export function deepMerge<T extends Record<string, unknown>>(
+  target: T,
+  ...sources: DeepPartial<T>[]
+): T {
+  const result = {...target};
+
+  for (const source of sources) {
+    for (const key in source) {
+      const sourceValue = source[key];
+      const targetValue = result[key as keyof T];
+
+      if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+        (result as Record<string, unknown>)[key] = deepMerge(
+          targetValue as Record<string, unknown>,
+          sourceValue as Record<string, unknown>,
+        );
+      } else if (sourceValue !== undefined) {
+        (result as Record<string, unknown>)[key] = sourceValue;
+      }
+    }
+  }
+
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/src/helpers/object.ts
+++ b/src/helpers/object.ts
@@ -20,9 +20,7 @@ export function pick<T extends Record<string, unknown>, K extends keyof T>(
 ): Pick<T, K> {
   const result = {} as Pick<T, K>;
 
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-
+  for (const key of keys) {
     if (obj[key] !== undefined) {
       result[key] = obj[key];
     }
@@ -32,7 +30,9 @@ export function pick<T extends Record<string, unknown>, K extends keyof T>(
 }
 
 type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : T[K];
+  [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : T[K];
 };
 
 /**
@@ -59,6 +59,30 @@ export function deepMerge<T extends Record<string, unknown>>(
       } else if (sourceValue !== undefined) {
         (result as Record<string, unknown>)[key] = sourceValue;
       }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Creates a new object omitting properties for which the predicate returns true.
+ * @example
+ * omitBy({ a: '', b: 'hello', c: '' }, v => v === '')
+ * // => { b: 'hello' }
+ */
+export function omitBy<T extends Record<string, unknown>>(
+  obj: T,
+  predicate: (value: T[keyof T], key: keyof T) => boolean,
+): Partial<T> {
+  const result: Partial<T> = {};
+
+  for (const key in obj) {
+    if (
+      Object.prototype.hasOwnProperty.call(obj, key) &&
+      !predicate(obj[key], key)
+    ) {
+      result[key] = obj[key];
     }
   }
 

--- a/src/sdk.authorization-url.test.ts
+++ b/src/sdk.authorization-url.test.ts
@@ -116,6 +116,15 @@ describe('sdk.authorizeURL()', function () {
       expect(q1.state).toBe('state1');
       expect(q2.state).toBe('state2');
     });
+
+    it('keeps non-empty params while omitting empty-string and null ones', function () {
+      const query = parseQuery(
+        sdk.authorizeURL({ organization_id: 'org_123', prompt: '', scope: null })
+      );
+      expect(query.organization_id).toBe('org_123');
+      expect(query.prompt).toBeUndefined();
+      expect(query.scope).toBeUndefined();
+    });
   });
 
   describe('response types', function () {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2,21 +2,14 @@ import Popup from './authentication/popup';
 import Redirect from './authentication/redirect';
 import Iframe from './authentication/iframe';
 import Transaction from './authentication/transaction';
-import {
-  type TransactionParams,
-  type TransactionData,
-  type VerifyInput,
-} from './types/transaction';
+import {type TransactionData, type VerifyInput} from './types/transaction';
 import qs from 'qs';
 import sjcl from './vendor/sjcl';
 import {pick} from './helpers/object';
 import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
-import {
-  type SDKOptions,
-  type ResolvedOptions,
-} from './types/sdk';
+import {type SDKOptions, type ResolvedOptions} from './types/sdk';
 import {type PersistParams} from './types/persister';
 import {
   type PopupSDK,
@@ -184,7 +177,10 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       }
     }
 
-    this.transaction.generate(params as TransactionParams);
+    this.transaction.generate({
+      state: localOptions.state,
+      code_verifier: params.code_verifier,
+    });
     this.redirectUriParamsPersister.persist(params as PersistParams);
 
     delete params.code_verifier;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -5,12 +5,11 @@ import Transaction from './authentication/transaction';
 import {type TransactionData, type VerifyInput} from './types/transaction';
 import qs from 'qs';
 import sjcl from './vendor/sjcl';
-import {pick} from './helpers/object';
+import {pick, deepMerge} from './helpers/object';
 import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
 import {type SDKOptions, type ResolvedOptions} from './types/sdk';
-import {type PersistParams} from './types/persister';
 import {
   type PopupSDK,
   type IframeSDK,
@@ -30,7 +29,8 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       throw new Error('client id not provided');
     }
 
-    const defaultOptions: Omit<ResolvedOptions, 'client_id'> = {
+    const defaultOptions: ResolvedOptions = {
+      client_id: '',
       organization_id: '',
       prompt: '',
       response_type: 'token',
@@ -58,7 +58,7 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       },
     };
 
-    this.options = Object.assign({}, defaultOptions, options);
+    this.options = deepMerge(defaultOptions, options);
     this.transaction = new Transaction(this.options);
     this.redirectUriParamsPersister = new RedirectUriParamsPersister(
       this.options,
@@ -69,7 +69,7 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
    * Use iframe for authorization. Not recommended due to ITP 2.0.
    */
   iframe(options: Partial<SDKOptions> = {}): Iframe {
-    const localOptions = Object.assign({}, this.options, options);
+    const localOptions = deepMerge(this.options, options);
     return new Iframe(this, localOptions);
   }
 
@@ -77,7 +77,7 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
    * Use popup for authorization. Must be called inside a click handler.
    */
   popup(options: Partial<SDKOptions> = {}): Popup {
-    const localOptions = Object.assign({}, this.options, options);
+    const localOptions = deepMerge(this.options, options);
     return new Popup(this, localOptions);
   }
 
@@ -85,7 +85,7 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
    * Use redirect for authorization.
    */
   redirect(options: Partial<SDKOptions> = {}): Redirect {
-    const localOptions = Object.assign({}, this.options, options);
+    const localOptions = deepMerge(this.options, options);
     return new Redirect(this, localOptions);
   }
 
@@ -95,11 +95,8 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
    * @param flow - Set to `'button'` for popup and iframe flows.
    */
   authorizeURL(options: Partial<SDKOptions> = {}, flow = ''): string {
-    const localOptions: ResolvedOptions = Object.assign(
-      {},
-      this.options,
-      options,
-    );
+    const localOptions: ResolvedOptions = deepMerge(this.options, options);
+
     if (!localOptions.state) {
       localOptions.state = random.string(localOptions.transaction.key_length);
     }
@@ -178,10 +175,13 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
     }
 
     this.transaction.generate({
-      state: localOptions.state,
+      state: params.state ?? localOptions.state,
       code_verifier: params.code_verifier,
     });
-    this.redirectUriParamsPersister.persist(params as PersistParams);
+    this.redirectUriParamsPersister.persist({
+      state: params.state ?? localOptions.state,
+      redirect_uri: params.redirect_uri ?? localOptions.redirect_uri,
+    });
 
     delete params.code_verifier;
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -5,7 +5,7 @@ import Transaction from './authentication/transaction';
 import {type TransactionData, type VerifyInput} from './types/transaction';
 import qs from 'qs';
 import sjcl from './vendor/sjcl';
-import {pick, deepMerge} from './helpers/object';
+import {pick, deepMerge, omitBy} from './helpers/object';
 import encoding from './helpers/encoding';
 import RedirectUriParamsPersister from './helpers/persisters/redirectUriParams';
 import random from './helpers/random';
@@ -105,15 +105,19 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       localOptions.redirect_uri = window.location.href;
     }
 
-    const params: Partial<ResolvedOptions> = pick(localOptions, [
-      'client_id',
-      'organization_id',
-      'redirect_uri',
-      'state',
-      'response_type',
-      'scope',
-      'prompt',
-    ]);
+    const params: Partial<ResolvedOptions> &
+      Pick<ResolvedOptions, 'redirect_uri' | 'state' | 'code_verifier'> = pick(
+      localOptions,
+      [
+        'client_id',
+        'organization_id',
+        'redirect_uri',
+        'state',
+        'response_type',
+        'scope',
+        'prompt',
+      ],
+    );
 
     Object.assign(params, localOptions.tracking);
 
@@ -174,18 +178,17 @@ export default class AccountsSDK implements PopupSDK, IframeSDK, RedirectSDK {
       }
     }
 
-    this.transaction.generate({
-      state: params.state ?? localOptions.state,
-      code_verifier: params.code_verifier,
-    });
-    this.redirectUriParamsPersister.persist({
-      state: params.state ?? localOptions.state,
-      redirect_uri: params.redirect_uri ?? localOptions.redirect_uri,
-    });
+    this.transaction.generate(params);
+    this.redirectUriParamsPersister.persist(params);
 
     delete params.code_verifier;
 
-    return url + '?' + qs.stringify(params);
+    const cleanedParams = omitBy(
+      params,
+      (value) => value === '' || value === null,
+    );
+
+    return url + '?' + qs.stringify(cleanedParams);
   }
 
   /**

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -12,18 +12,18 @@ export type TokenFlowResponse = {
   /** Token lifetime in seconds. */
   expires_in: number;
   /** Granted scopes as a comma-separated string (e.g. `'read,write'`). */
-  scope: string;
+  scope?: string;
   /**
    * The `state` value that was passed to the authorization request.
    * Used to match the response to the initiating request.
    */
-  state: string;
+  state?: string;
   /** UUID of the authenticated account. */
-  account_id: string;
+  account_id?: string;
   /** UUID of the organization the token belongs to. */
-  organization_id: string;
+  organization_id?: string;
   /** OAuth2 client ID of the application that requested the token. */
-  client_id: string;
+  client_id?: string;
 };
 
 /**
@@ -40,15 +40,15 @@ export type CodeFlowResponse = {
    * The `state` value that was passed to the authorization request.
    * Used to match the response to the initiating request.
    */
-  state: string;
+  state?: string;
   /** Granted scopes as a comma-separated string (e.g. `'read,write'`). */
-  scope: string;
+  scope?: string;
   /** UUID of the organization the session belongs to. */
-  organization_id: string;
+  organization_id?: string;
   /** UUID of the authenticated account. */
-  account_id: string;
+  account_id?: string;
   /** OAuth2 client ID of the application that requested the code. */
-  client_id: string;
+  client_id?: string;
   expires_in?: never;
 };
 


### PR DESCRIPTION
## 🚀 Links
[AS-928]

## 📓 Description:
Fixes issue where the `state` passed to `transaction.generate(params)` was `undefined` and caused to save in the local storage the value `namespace + undefined`. This might have led to infinite loops when authorizing using `CodeFlowResponse`.

## 👷 Types of changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a new functionality)
- [ ] Breaking change (fix or feature change that would cause existing functionality to change)
- [ ] Non-code change (e.g., documentation, CI/CD configuration, dependencies update, etc.)


[AS-928]: https://livechatinc.atlassian.net/browse/AS-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ