### PR TITLE
chore: AS-1372 update dependabot schedule to bi-weekly cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
+      interval: 'cron'
+      cronjob: '0 9 1,15 * *'
       timezone: 'Europe/Warsaw'
     open-pull-requests-limit: 10
     commit-message:
@@ -33,9 +32,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
+      interval: 'cron'
+      cronjob: '0 9 1,15 * *'
       timezone: 'Europe/Warsaw'
     open-pull-requests-limit: 5
     commit-message:


### PR DESCRIPTION
## Summary

- Switch dependabot schedule from `weekly` (every Monday) to `cron: 0 9 1,15 * *` (1st and 15th of each month at 09:00 Europe/Warsaw)
- Applied to both `npm` and `github-actions` ecosystems
- Reduces dependency PR noise from ~4x/month to ~2x/month

Relates to [AS-1372](https://livechatinc.atlassian.net/browse/AS-1372)

[AS-1372]: https://livechatinc.atlassian.net/browse/AS-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ